### PR TITLE
web_links call does not return if freebase has no results

### DIFF
--- a/freebase.js
+++ b/freebase.js
@@ -161,7 +161,7 @@ exports.get_weblinks=function(q, callback, query){
      var weblinks=response.result[0]["/common/topic/weblink"];
      return callback(weblinks);
      }
-     else{return callback=null;}
+     else{return callback(null)}
    }, {extended:true});
 }
 


### PR DESCRIPTION
fix web_links call not returning if no results are returned from freebase
