### PR TITLE
Add dateline parameter to mqlread

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -45,6 +45,10 @@ var freebase = (function() {
         options.uniqueness_failure = options.uniqueness_failure || "soft";
         options.cursor = options.cursor || "";
         var url = freebase.globals.host + 'mqlread?query=' + JSON.stringify(query) + "&cursor=" + options.cursor
+        if (options.dateline) {
+            url += "&dateline=" + dateline;
+        }
+
         fns.http(url, options, function(result) {
             if (result && result.error) {
                 console.log(JSON.stringify(result.error, null, 2));


### PR DESCRIPTION
Allows the caller of mqlread to supply a dateline in order to get consistent results. This is especially useful when in combination with mqlwrite to avoid caching issues.
