### PR TITLE
add option for not escaping mqlread() results

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -48,6 +48,9 @@ var freebase = (function() {
         if (options.dateline) {
             url += "&dateline=" + dateline;
         }
+        if (options.html_escape === false) {
+            url += '&html_escape=false';
+        }
 
         fns.http(url, options, function(result) {
             if (result && result.error) {


### PR DESCRIPTION
I'm working on the command line and want my results to not be HTML escaped (so I get the string `Sid & Nancy` rather than `Sid &amp; Nancy`). So I added the option.
